### PR TITLE
Mechanum Drive Command

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -17,4 +17,6 @@ public final class Constants {
     public static int rightRearID = 1;
     public static int leftFrontID = 2;
     public static int leftRearID = 3;
+
+    public static int fieldOrientedDriveButton = 5;
 }

--- a/src/main/java/frc/robot/commands/ManualDrive.java
+++ b/src/main/java/frc/robot/commands/ManualDrive.java
@@ -6,6 +6,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.Constants;
 import frc.robot.subsystems.Drivetrain;
@@ -34,6 +35,13 @@ public class ManualDrive extends CommandBase {
 
     if (this.joystick.getRawButtonPressed(Constants.fieldOrientedDriveButton)) {  // only toggle when the button is pressed and not held
       this.fieldOriented = !this.fieldOriented;  // invert the toggle
+
+      SmartDashboard.putString(  // update the dashboard
+        "Drive Mode",
+        this.fieldOriented ? "Field Oriented" : "Relative"
+      );
+      // If this doesn't work right away, try running `SmartDashboard.updateValues` in the robot's `periodic`
+
     }
 
     this.drivetrain.setDriveOutput(

--- a/src/main/java/frc/robot/commands/ManualDrive.java
+++ b/src/main/java/frc/robot/commands/ManualDrive.java
@@ -1,0 +1,46 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
+import frc.robot.subsystems.Drivetrain;
+
+/** Drive the robot with the joystick, through a  */
+public class ManualDrive extends CommandBase {
+  private Drivetrain drivetrain;
+  private Joystick joystick;
+  private boolean fieldOriented;
+
+  /** Creates a new ManualDrive. */
+  public ManualDrive(Drivetrain drivetrain, Joystick joystick) {
+    this.drivetrain = drivetrain;
+    this.joystick = joystick;
+    this.fieldOriented = false;  // start as relative driving
+
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(drivetrain);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    Translation2d joystickVector = new Translation2d(this.joystick.getX(), this.joystick.getY());
+    double rotationalVelocity = this.joystick.getTwist();
+
+    if (this.joystick.getRawButtonPressed(Constants.fieldOrientedDriveButton)) {  // only toggle when the button is pressed and not held
+      this.fieldOriented = !this.fieldOriented;  // invert the toggle
+    }
+
+    this.drivetrain.setDriveOutput(
+      joystickVector,
+      rotationalVelocity,
+      this.fieldOriented
+    );
+
+  }
+}

--- a/src/main/java/frc/robot/commands/ResetGyro.java
+++ b/src/main/java/frc/robot/commands/ResetGyro.java
@@ -1,0 +1,25 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import frc.robot.subsystems.Drivetrain;
+
+/** A command that resets the drivetrain's gyro to a heading of zero */
+public class ResetGyro extends InstantCommand {
+  private Drivetrain drivetrain;
+
+  public ResetGyro(Drivetrain drivetrain) {
+    this.drivetrain = drivetrain;
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(drivetrain);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    this.drivetrain.resetGyro();
+  }
+}

--- a/src/main/java/frc/robot/commands/ResetGyro.java
+++ b/src/main/java/frc/robot/commands/ResetGyro.java
@@ -13,8 +13,6 @@ public class ResetGyro extends InstantCommand {
 
   public ResetGyro(Drivetrain drivetrain) {
     this.drivetrain = drivetrain;
-    // Use addRequirements() here to declare subsystem dependencies.
-    addRequirements(drivetrain);
   }
 
   // Called when the command is initially scheduled.

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -63,4 +63,9 @@ public class Drivetrain extends SubsystemBase {
     }
     this.driveGroup.driveCartesian(driveVector.getX(), -driveVector.getY(), -rotationalVelocity);
   }
+
+  /**Resets the gyro to a heading of zero */
+  public void resetGyro(){
+    this.gyro.reset();
+  }
 }


### PR DESCRIPTION
Adds commands to drive a mecanum robot, along with some supporting commands

[Checklist](https://github.com/Creekside-Robotics/Offseason-Mecanum-Bot/issues/3):
- [x] Command to drive the robot with a joystick
  - [x] Joystick coordinates -> WPILIB coordinates/movements
  - [x] Relative drive (default)
  - [x] Field oriented drive (activated with button)
- [x] InstantCommand to reset the gyro
  - [x] Drivetrain method to reset the gyro

Closes #3 